### PR TITLE
Fixed the replaceHour regex.

### DIFF
--- a/weather-update/build.gradle
+++ b/weather-update/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group 'com.marlan'
-version '2.1.9'
+version '2.1.10'
 
 repositories {
     mavenCentral()

--- a/weather-update/src/main/java/com/marlan/weatherupdate/service/missioneditor/MissionEditor.java
+++ b/weather-update/src/main/java/com/marlan/weatherupdate/service/missioneditor/MissionEditor.java
@@ -133,7 +133,7 @@ public class MissionEditor {
 
     @NotNull
     private String replaceHour(String mission, float hour) {
-        Pattern pattern = Pattern.compile("^\\s{4}\\[\"start_time\"]\\s=\\s.*,$", Pattern.MULTILINE);
+        Pattern pattern = Pattern.compile("(?:\\s{4}|\\t)\\[\"start_time\"]\\s=\\s.*,", Pattern.MULTILINE);
         Matcher matcher = pattern.matcher(mission);
         if (!matcher.find()) {
             log.error("Regex match failed, Hour not set.");


### PR DESCRIPTION
DCS changed miz format from 4 spaces to tabs making the start_time regex not work. This one supports both 4 spaces and tabs.